### PR TITLE
プロンプトのカーソル位置がズレる問題を修正

### DIFF
--- a/src/.config/cmux/auto-layout.zsh
+++ b/src/.config/cmux/auto-layout.zsh
@@ -14,5 +14,18 @@ _cmux_auto_layout() {
   fi
 }
 
+# cmux new-splitがPTYサイズを更新しないバグの回避策
+# ANSIエスケープシーケンスで実サイズを取得しsttyで設定する
+_cmux_fix_pty_size() {
+  add-zsh-hook -d precmd _cmux_fix_pty_size
+  local rows cols
+  printf '\e7\e[9999;9999H\e[6n\e8' > /dev/tty
+  IFS='[;' read -sdR _ rows cols < /dev/tty
+  if [[ -n "$cols" && -n "$rows" && "$cols" != "$COLUMNS" ]]; then
+    command stty rows "$rows" columns "$cols" < /dev/tty
+  fi
+}
+
 autoload -Uz add-zsh-hook
 add-zsh-hook precmd _cmux_auto_layout
+add-zsh-hook precmd _cmux_fix_pty_size


### PR DESCRIPTION
## チケットへのリンク
<!-- チケットの番号を追加(EN-チケット番号) -->
- [該当チケット](https://yutanakano.atlassian.net/browse/DOT-7)

## やったこと
<!-- 箇条書きで書く -->
> - 作業内容



## 動作確認
<!-- チェックボックス付きの箇条書きで書く -->
> - [ ] 確認内容



## その他
<!-- 実装上の懸念点や注意点などあれば記載 -->
> - 気になる内容

cmuxのnew-splitがPTYのウィンドウサイズを更新しないため、
シェルのCOLUMNS/LINESがsplit前の値のまま残り、
プロンプトのカーソル位置がズレる問題の回避策。

ANSIエスケープシーケンス(DSR)で実際のターミナルサイズを取得し、
sttyで正しいPTYサイズを設定するprecmdフックを追加。
