### PR TITLE
Homebrewサブシェルで設定されたPATHを親プロセスに引き継ぐ

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -8,6 +8,13 @@ CURRENT="$(cd "$(dirname "$0")" && pwd)"
 # 1. Homebrew + パッケージインストール
 sh "$CURRENT/scripts/homebrew/init.sh" || { echo "エラー: Homebrewのセットアップに失敗しました"; exit 1; }
 
+# Homebrew のPATHを引き継ぐ（サブシェルで設定されたPATHは親に伝播しないため）
+if [ -x /opt/homebrew/bin/brew ]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -x /usr/local/bin/brew ]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+fi
+
 # 2. dotfiles (stow + yazi + gitconfig)
 sh "$CURRENT/scripts/dotfiles/init.sh" || { echo "エラー: dotfilesの設定に失敗しました"; exit 1; }
 


### PR DESCRIPTION
homebrew/init.shがサブシェルで実行されるため、そこで設定されたPATHが
後続のdotfiles/init.shに伝播せずstowが見つからない問題を修正

## チケットへのリンク
<!-- チケットの番号を追加(EN-チケット番号) -->
- [該当チケット](https://yutanakano.atlassian.net/browse/DOT-)

## やったこと
<!-- 箇条書きで書く -->
> - 作業内容



## 動作確認
<!-- チェックボックス付きの箇条書きで書く -->
> - [ ] 確認内容



## その他
<!-- 実装上の懸念点や注意点などあれば記載 -->
> - 気になる内容


